### PR TITLE
Do not display external link element on home page when field values…

### DIFF
--- a/website-content/themes/jsarc/page-home.php
+++ b/website-content/themes/jsarc/page-home.php
@@ -671,7 +671,14 @@ endif;
                 <p class="hero-intro"><?php the_sub_field( 'intro' ); ?></p>
                 <?php if ( have_rows( 'button' ) ) : ?>
                 <?php while ( have_rows( 'button' ) ) : the_row(); ?>
-                <a class="button more" href="<?php the_sub_field( 'url' ); ?>"><?php the_sub_field( 'text' ); ?><?php if ( get_sub_field( 'hidden_text' ) ) { ?> <span class="visuallyhidden"><?php the_sub_field( 'hidden_text' ); ?><?php } ?></a>
+                    <?php if ( get_sub_field( 'hidden_text' ) &&
+                     get_sub_field( 'text' ) &&
+                      get_sub_field( 'url' ) ) { ?>
+                        <a class="button more" href="<?php the_sub_field( 'url' ); ?>">
+                            <?php the_sub_field( 'text' ); ?>
+                            <span class="visuallyhidden"><?php the_sub_field( 'hidden_text' ); ?>
+                        </a>
+                    <?php } ?>
                 <?php endwhile; ?>
                 <?php endif; ?>
             </div>


### PR DESCRIPTION
Ref.: INC2508677

Our colleague Edar investigated the issue and we concluded that the home page is 'broken'.  However, I think he was able to make a past-fix on the frontend, i.e. with the custom fields that allow the adding and removing of external web links to the banner.

**This MR attempts to complete the fix by making a change to the backend, i.e. a template change.  Basically, if the text value does not exist, then do not display it.**

In my local testing, I have found that with this change the temporary fix to the Live (that the client, e.g. Theresa is happy with), i.e. CSS code that hides the link, will no longer be required.